### PR TITLE
Support 32bit arm

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,5 +37,7 @@ _download_url() {
 
 echo "Downloading k0s from URL: $(_download_url)"
 
-curl -sSLf $(_download_url) > /usr/bin/k0s
-chmod 755 /usr/bin/k0s
+curl -sSLf $(_download_url) > /usr/local/bin/k0s
+chmod 755 /usr/local/bin/k0s
+
+echo "k0s is now executable in /usr/local/bin"


### PR DESCRIPTION
Also change the location for the binary to comply with Unix standards:
```
Locally installed software must be placed within /usr/local rather than /usr unless it is being installed to
replace or upgrade software in /usr.
```
See: https://www.pathname.com/fhs/pub/fhs-2.3.pdf

Can we just always rely on the fact that `/usr/local/bin` already exists, or should there be some `mkdir -p ...` also done?