### PR TITLE
Detect operating system

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,36 +2,56 @@
 
 set -e
 
+if [ -n "${DEBUG}" ]; then
+  set -x
+fi
+
 _k0s_latest() {
   curl -sSLf "https://docs.k0sproject.io/stable.txt"
 }
 
-if [ "${K0S_VERSION}" = "" ]; then
-  K0S_VERSION=$(_k0s_latest)
-fi
-
-if [ ! -z "${DEBUG}" ]; then
-  set -x
-fi
+_detect_binary() {
+  os="$(uname)"
+  case "$os" in
+    Linux) echo "k0s" ;;
+    *) echo "Unsupported operating system: $os" 1>&2; return 1 ;;
+  esac
+  unset os
+}
 
 _detect_arch() {
-  case $(uname -m) in
+  arch="$(uname -m)"
+  case "$arch" in
     amd64|x86_64) echo "amd64" ;;
     arm64|aarch64) echo "arm64" ;;
     armv7l|armv8l|arm) echo "arm" ;;
-    *) echo "Unsupported processor architecture"; return 1 ;;
+    *) echo "Unsupported processor architecture: $arch" 1>&2; return 1 ;;
   esac
+  unset arch
 }
 
 _download_url() {
-  local arch="$(_detect_arch)"
-
-  echo "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/k0s-$K0S_VERSION-$arch"
+  echo "https://github.com/k0sproject/k0s/releases/download/$K0S_VERSION/$k0sBinary-$K0S_VERSION-$k0sArch"
 }
 
-echo "Downloading k0s from URL: $(_download_url)"
+main() {
+  if [ -z "${K0S_VERSION}" ]; then
+    K0S_VERSION=$(_k0s_latest)
+  fi
 
-curl -sSLf $(_download_url) > /usr/local/bin/k0s
-chmod 755 /usr/local/bin/k0s
+  k0sInstallPath=/usr/local/bin
+  k0sBinary="$(_detect_binary)"
+  k0sArch="$(_detect_arch)"
+  k0sDownloadUrl="$(_download_url)"
 
-echo "k0s is now executable in /usr/local/bin"
+  mkdir -p -- "$k0sInstallPath"
+
+  echo "Downloading k0s from URL: $k0sDownloadUrl"
+
+  curl -sSLf "$k0sDownloadUrl" >"$k0sInstallPath/$k0sBinary"
+  chmod 755 -- "$k0sInstallPath/$k0sBinary"
+
+  echo "k0s is now executable in $k0sInstallPath"
+}
+
+main


### PR DESCRIPTION
The script currently only supports Linux, but won't verify this fact. Hence, it'll just succeed on other OSes by installing a non-functional binary.

* Add a _detect_binary function that produces the binary name to download, and verifies the OS in that process.
* Refactor the script to have a k0sInstallPath variable, so that it can be tested locally by just changing the install path.
* Make sure the install path actually exists.
* Print error messages to stderr, so that they're actually shown on the terminal.
* Remove usages of the local keyword, since this is not part of POSIX.

Fixes k0sproject/k0s#1603.